### PR TITLE
This commit refactors the punishment logic to be per-player and use t…

### DIFF
--- a/core/src/main/java/better/anticheat/core/check/Check.java
+++ b/core/src/main/java/better/anticheat/core/check/Check.java
@@ -187,7 +187,7 @@ public abstract class Check implements Cloneable {
          */
         for (PunishmentGroup group : punishmentGroups) {
             if (group != null) {
-                plugin.getPunishmentManager().incrementGroupVl(group.getName());
+                plugin.getPunishmentManager().incrementGroupVl(player, group.getName());
             }
         }
         plugin.getPunishmentManager().runPunishments(this);

--- a/core/src/main/java/better/anticheat/core/player/Player.java
+++ b/core/src/main/java/better/anticheat/core/player/Player.java
@@ -24,6 +24,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Getter
 public class Player implements Closeable {
@@ -47,6 +50,7 @@ public class Player implements Closeable {
     private boolean alerts = false, verbose = false;
 
     private final List<Closeable> closeables = new ArrayList<>();
+    private final Map<String, AtomicInteger> groupViolations = new ConcurrentHashMap<>();
 
     public Player(final BetterAnticheat plugin, final User user, final DataBridge dataBridge) {
         this.plugin = plugin;

--- a/core/src/main/java/better/anticheat/core/player/PlayerManager.java
+++ b/core/src/main/java/better/anticheat/core/player/PlayerManager.java
@@ -55,9 +55,10 @@ public class PlayerManager {
     }
 
     public synchronized void removeUser(User user) throws IOException {
-        idMap.remove(user.getEntityId());
         final var removedPlayer = userMap.remove(user);
         if (removedPlayer == null) return;
+
+        idMap.remove(user.getEntityId());
         removedPlayer.close();
     }
 

--- a/core/src/main/java/better/anticheat/core/player/PlayerManager.java
+++ b/core/src/main/java/better/anticheat/core/player/PlayerManager.java
@@ -55,10 +55,9 @@ public class PlayerManager {
     }
 
     public synchronized void removeUser(User user) throws IOException {
+        idMap.remove(user.getEntityId());
         final var removedPlayer = userMap.remove(user);
         if (removedPlayer == null) return;
-
-        idMap.remove(user.getEntityId());
         removedPlayer.close();
     }
 

--- a/core/src/main/java/better/anticheat/core/punishment/PunishmentGroup.java
+++ b/core/src/main/java/better/anticheat/core/punishment/PunishmentGroup.java
@@ -4,10 +4,14 @@ import lombok.Data;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Data
 public class PunishmentGroup {
     private final String name;
     private final Map<Integer, List<String>> perGroupPunishments;
     private final Map<Integer, List<String>> perCheckPunishments;
+    private final Map<UUID, AtomicInteger> groupViolations = new ConcurrentHashMap<>();
 }

--- a/core/src/main/java/better/anticheat/core/punishment/PunishmentGroup.java
+++ b/core/src/main/java/better/anticheat/core/punishment/PunishmentGroup.java
@@ -4,14 +4,9 @@ import lombok.Data;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 @Data
 public class PunishmentGroup {
     private final String name;
     private final Map<Integer, List<String>> perGroupPunishments;
     private final Map<Integer, List<String>> perCheckPunishments;
-    private final Map<UUID, AtomicInteger> groupViolations = new ConcurrentHashMap<>();
 }

--- a/core/src/main/java/better/anticheat/core/punishment/PunishmentManager.java
+++ b/core/src/main/java/better/anticheat/core/punishment/PunishmentManager.java
@@ -69,12 +69,14 @@ public class PunishmentManager {
             if (plugin.isPunishmentModulo()) {
                 // Handle group punishments
                 for (int punishVl : group.getPerGroupPunishments().keySet()) {
+                    if (punishVl == 0) continue;
                     if (groupVl % punishVl == 0) {
                         runPunishment(check, punishVl, group.getPerGroupPunishments());
                     }
                 }
                 // Handle check punishments
                 for (int punishVl : group.getPerCheckPunishments().keySet()) {
+                    if (punishVl == 0) continue;
                     if (checkVl % punishVl == 0) {
                         runPunishment(check, punishVl, group.getPerCheckPunishments());
                     }

--- a/core/src/main/java/better/anticheat/core/punishment/PunishmentManager.java
+++ b/core/src/main/java/better/anticheat/core/punishment/PunishmentManager.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -95,13 +94,13 @@ public class PunishmentManager {
 
 
     public void incrementGroupVl(Player player, String groupName) {
-        getPunishmentGroup(groupName).getGroupViolations()
-                .computeIfAbsent(player.getUser().getUUID(), k -> new AtomicInteger(0)).incrementAndGet();
+        player.getGroupViolations()
+                .computeIfAbsent(groupName, k -> new AtomicInteger(0)).incrementAndGet();
     }
 
     public int getGroupVl(Player player, String groupName) {
-        return getPunishmentGroup(groupName).getGroupViolations()
-                .getOrDefault(player.getUser().getUUID(), new AtomicInteger(0)).get();
+        return player.getGroupViolations()
+                .getOrDefault(groupName, new AtomicInteger(0)).get();
     }
 
     private void runPunishment(Check check, int vl, Map<Integer, List<String>> punishmentMap) {

--- a/core/src/main/java/better/anticheat/core/punishment/PunishmentManager.java
+++ b/core/src/main/java/better/anticheat/core/punishment/PunishmentManager.java
@@ -3,24 +3,25 @@ package better.anticheat.core.punishment;
 import better.anticheat.core.BetterAnticheat;
 import better.anticheat.core.check.Check;
 import better.anticheat.core.configuration.ConfigSection;
+import better.anticheat.core.player.Player;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @RequiredArgsConstructor
 public class PunishmentManager {
 
     private final BetterAnticheat plugin;
     private final Map<String, PunishmentGroup> punishmentGroups = new ConcurrentHashMap<>();
-    private final Map<String, Integer> groupViolations = new ConcurrentHashMap<>();
 
     public void load() {
         punishmentGroups.clear();
-        groupViolations.clear();
         ConfigSection section = plugin.getFile("settings.yml").getRoot().getConfigSection("punishment-groups");
         if (section == null) {
             plugin.getDataBridge().logWarning("Punishment groups section not found in settings.yml!");
@@ -63,36 +64,44 @@ public class PunishmentManager {
     }
 
     public void runPunishments(Check check) {
-        int vl = check.getVl();
-        if (plugin.isPunishmentModulo()) {
-            for (PunishmentGroup group : check.getPunishmentGroups()) {
-                for (int punishVL : group.getPerGroupPunishments().keySet()) {
-                    if (vl % punishVL != 0) continue;
-                    runPunishment(check, punishVL, group.getPerGroupPunishments());
+        int checkVl = check.getVl();
+        for (PunishmentGroup group : check.getPunishmentGroups()) {
+            int groupVl = getGroupVl(check.getPlayer(), group.getName());
+            if (plugin.isPunishmentModulo()) {
+                // Handle group punishments
+                for (int punishVl : group.getPerGroupPunishments().keySet()) {
+                    if (groupVl % punishVl == 0) {
+                        runPunishment(check, punishVl, group.getPerGroupPunishments());
+                    }
                 }
-                for (int punishVL : group.getPerCheckPunishments().keySet()) {
-                    if (vl % punishVL != 0) continue;
-                    runPunishment(check, punishVL, group.getPerCheckPunishments());
+                // Handle check punishments
+                for (int punishVl : group.getPerCheckPunishments().keySet()) {
+                    if (checkVl % punishVl == 0) {
+                        runPunishment(check, punishVl, group.getPerCheckPunishments());
+                    }
                 }
-            }
-        } else {
-            for (PunishmentGroup group : check.getPunishmentGroups()) {
-                if (group.getPerGroupPunishments().containsKey(vl)) {
-                    runPunishment(check, vl, group.getPerGroupPunishments());
+            } else {
+                // Handle group punishments
+                if (group.getPerGroupPunishments().containsKey(groupVl)) {
+                    runPunishment(check, groupVl, group.getPerGroupPunishments());
                 }
-                if (group.getPerCheckPunishments().containsKey(vl)) {
-                    runPunishment(check, vl, group.getPerCheckPunishments());
+                // Handle check punishments
+                if (group.getPerCheckPunishments().containsKey(checkVl)) {
+                    runPunishment(check, checkVl, group.getPerCheckPunishments());
                 }
             }
         }
     }
 
-    public void incrementGroupVl(String groupName) {
-        groupViolations.put(groupName, groupViolations.getOrDefault(groupName, 0) + 1);
+
+    public void incrementGroupVl(Player player, String groupName) {
+        getPunishmentGroup(groupName).getGroupViolations()
+                .computeIfAbsent(player.getUser().getUUID(), k -> new AtomicInteger(0)).incrementAndGet();
     }
 
-    public int getGroupVl(String groupName) {
-        return groupViolations.getOrDefault(groupName, 0);
+    public int getGroupVl(Player player, String groupName) {
+        return getPunishmentGroup(groupName).getGroupViolations()
+                .getOrDefault(player.getUser().getUUID(), new AtomicInteger(0)).get();
     }
 
     private void runPunishment(Check check, int vl, Map<Integer, List<String>> punishmentMap) {


### PR DESCRIPTION
…he correct violation level for each punishment type.

The `groupViolations` map has been moved from `PunishmentManager` to `PunishmentGroup` to track violations on a per-player basis. The `incrementGroupVl` and `getGroupVl` methods in `PunishmentManager` have been updated to accept a player identifier and interact with the new map.

The `runPunishments` method in `PunishmentManager` has been refactored to use the correct violation level for each punishment type and to remove duplicated code.